### PR TITLE
调整 QuickShop 部分

### DIFF
--- a/docs-java/process/plugin/other/QuickShop.md
+++ b/docs-java/process/plugin/other/QuickShop.md
@@ -25,6 +25,8 @@ sidebar_label: 商店 - QuickShop
 [PotatoCraft-Studio](https://github.com/PotatoCraft-Studio) 团队的 [QuickShop-Reremake](#quickshop-reremakepotatocraft-studio) 的后续版本 [QuickShop-Hikari](#quickshop-hikari) 目前由 [creatorfromhell](https://github.com/creatorfromhell) 维护
 
 `插件百科` https://mineplugin.org/QuickShop
+`QuickShop-Hikari插件百科` https://quickshop-community.github.io/QuickShop-Hikari-Documents/
+
 
 <!--markdownlint-disable line-length-->
 
@@ -42,35 +44,26 @@ sidebar_label: 商店 - QuickShop
 
 停止维护
 
-## QuickShop-Reremake(Ghost-chu)
+## QuickShop-Reremake(Ghost-chu/PotatoCraft-Studio)
 
 :::info
 
 `Bukkit` https://dev.bukkit.org/projects/quickshop-reremake
-
-`GitHub` https://github.com/KaiKikuchi/QuickShop
-
-:::
-
-![](https://bstats.org/signatures/bukkit/QuickShop-Reremake.svg)
-
-停止维护
-
-## QuickShop-Reremake(PotatoCraft-Studio)
-
-:::info
 
 `SpigotMC` https://www.spigotmc.org/resources/.62575
 
 `GitHub` https://github.com/PotatoCraft-Studio/QuickShop-Reremake
 
 :::
+![](https://bstats.org/signatures/bukkit/QuickShop-Reremake.svg)
 
 停止维护
 
 ## QuickShop-Hikari
 
 :::info
+
+`Modrinth` https://modrinth.com/plugin/quickshop-hikari
 
 `SpigotMC` https://www.spigotmc.org/resources/.100125
 


### PR DESCRIPTION
修复 info 中 QuickShop-Reremake 部分指向了错误的 Github 仓库链接
添加 QuickShop-Hikari 的插件百科
info 中添加 QuickShop-Hikari 的 Modrinth 链接
将 Ghost-chu 与 PotatoCraft-Studio 的 QuickShop-Reremake 合并到一起，因为这两个版本除了 Github 仓库不一样，其余链接应该都指向的是一样的资源